### PR TITLE
Fix: improve copying of plain text contents when callout is folded

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Educating the mind without educating the heart is no education at all.
 It is the mark of an educated mind to be able to entertain a thought without accepting it.
 ```
 
+> [!NOTE]
+> Under the hood, this uses the `innerText` HTML attribute, which may lead to slight inconsistencies in the copied content depending on whether a callout is folded or expanded; particularly in terms of whitespace.
+
 ## Contributing & Feedback
 
 My capacity may be limited for this plugin, but feel free to [open an issue](https://github.com/alythobani/obsidian-callout-copy-buttons/issues) for any bug reports or feature requests and I'll take a look if I do have time. Also feel free to submit a pull request or fork the project.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "callout-copy-buttons",
   "name": "Callout Copy Buttons",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "minAppVersion": "1.7.7",
   "description": "Adds copy buttons to callout blocks in your notes.",
   "author": "Aly Thobani",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./main.js",
   "author": "Aly Thobani",
   "license": "GPL-3.0-only",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "build": "npx webpack",
     "watch": "npx webpack --watch",

--- a/src/copyButton.ts
+++ b/src/copyButton.ts
@@ -49,6 +49,11 @@ async function onCopyButtonClick({
     return;
   }
 
+  if (calloutBodyText === "") {
+    new Notice("Callout Copy Buttons: Nothing to copy");
+    return;
+  }
+
   await navigator.clipboard.writeText(calloutBodyText);
 
   // console.log(`Copied: ${JSON.stringify(calloutBodyText)}`);

--- a/src/utils/addCopyButtonToCallout.ts
+++ b/src/utils/addCopyButtonToCallout.ts
@@ -1,7 +1,7 @@
 import classNames from "classnames";
 import { createCopyButton } from "../copyButton";
 import { type PluginSettingsManager } from "../settings";
-import { getCalloutBodyTextFromInnerText } from "./getCalloutBodyText";
+import { getCalloutBodyPlainText } from "./getCalloutBodyText";
 
 export function addCopyPlainTextButtonToCalloutDiv({
   calloutNode,
@@ -18,7 +18,7 @@ export function addCopyPlainTextButtonToCalloutDiv({
   }
   addCopyButtonToCallout({
     calloutNode,
-    getCalloutBodyText: () => getCalloutBodyTextFromInnerText(calloutNode),
+    getCalloutBodyText: () => getCalloutBodyPlainText(calloutNode),
     tooltipText: "Copy (plain text)",
     buttonClassName: "callout-copy-button-plain-text",
     isCMCalloutNode,

--- a/src/utils/getCalloutBodyText.ts
+++ b/src/utils/getCalloutBodyText.ts
@@ -3,8 +3,19 @@ import { type MarkdownSectionInformation } from "obsidian";
 
 const CALLOUT_HEADER_WITH_INDENT_CAPTURE_REGEX = /^((?:> )+)\[!.+\]/;
 
-export function getCalloutBodyTextFromInnerText(calloutNode: HTMLElement): string {
-  return calloutNode.innerText.split("\n").slice(1).join("\n").trim();
+/**
+ * Gets the body content of the given callout node, in plain text format, from the `innerText` HTML
+ * attribute of the node's `.callout-content` child div if found, else the callout node itself (in
+ * which case we strip off the first line which corresponds to the callout header).
+ *
+ * Trims any leading/trailing whitespace before returning.
+ */
+export function getCalloutBodyPlainText(calloutNode: HTMLElement): string {
+  const maybeBodyFromCalloutContentDiv =
+    calloutNode.querySelector<HTMLDivElement>("div.callout-content")?.innerText;
+  const calloutBodyContent =
+    maybeBodyFromCalloutContentDiv ?? calloutNode.innerText.split("\n").slice(1).join("\n");
+  return calloutBodyContent.replace(/\n\n\n+/g, "\n\n").trim();
 }
 
 /**


### PR DESCRIPTION
- add guard rail to not copy empty text to clipboard
- first try to copy plain text from `.callout-content` div if possible, which has a nonempty
      `innerText` even when the callout is folded

