### PR TITLE
feat: add copy markdown button in source mode live preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
-  "name": "obsidian-callout-copy-button",
-  "version": "1.0.0",
+  "name": "obsidian-callout-copy-buttons",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "obsidian-callout-copy-button",
-      "version": "1.0.0",
+      "name": "obsidian-callout-copy-buttons",
+      "version": "1.0.2",
       "license": "GPL-3.0-only",
       "dependencies": {
         "classnames": "^2.5.1",
         "obsidian": "^1.7.2"
       },
       "devDependencies": {
+        "@codemirror/state": "^6.5.4",
+        "@codemirror/view": "^6.39.11",
         "@eslint/js": "^9.17.0",
         "@types/node": "^22.10.2",
         "@types/webpack": "^5.28.5",
@@ -27,21 +29,24 @@
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
-      "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
+      "integrity": "sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.36.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.1.tgz",
-      "integrity": "sha512-miD1nyT4m4uopZaDdO2uXU/LLHliKNYL9kB1C1wJHrunHLm/rpkb5QVSokqgw9hFqEZakrdlb/VGWX8aYZTslQ==",
+      "version": "6.39.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.11.tgz",
+      "integrity": "sha512-bWdeR8gWM87l4DB/kYSF9A+dVackzDb/V56Tq7QVrQ7rn86W0rgZFtlL3g3pem6AeGcb9NQNoy3ao4WpW4h5tQ==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
       }
@@ -318,7 +323,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -423,6 +428,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
       "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -480,6 +486,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.18.2.tgz",
       "integrity": "sha512-y7tcq4StgxQD4mDr9+Jb26dZ+HTZ/SkfqpXSiqeUXZHxOUyjWDKsmwKhJ0/tApR08DgOhrFAoAhyB80/p3ViuA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.18.2",
         "@typescript-eslint/types": "8.18.2",
@@ -849,6 +856,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -882,6 +890,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1015,6 +1024,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -1149,6 +1159,12 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1258,6 +1274,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.17.0.tgz",
       "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2448,10 +2465,10 @@
       }
     },
     "node_modules/style-mod": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
-      "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
-      "peer": true
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -2543,6 +2560,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2695,6 +2713,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2780,7 +2799,7 @@
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/watchpack": {
       "version": "2.4.2",
@@ -2800,6 +2819,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
       "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -2846,6 +2866,7 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,10 +83,11 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
-      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -122,12 +123,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.1.tgz",
-      "integrity": "sha512-fo6Mtm5mWyKjA/Chy1BYTdn5mGJoDNjC7C64ug20ADsRDGrA85bN3uK3MaKbeRkRuuIEAR5N33Jr1pbm411/PA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.5",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -135,11 +137,25 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/core": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.1.tgz",
-      "integrity": "sha512-GuUdqkyyzQI5RMIWkHhvTWLCyLo1jNK3vzkSyaExH5kHPDHcuL2VOpHjmMY+y3+NC69qAKToBqldTBgYeLSr9Q==",
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -148,10 +164,11 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
-      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -159,7 +176,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.1.1",
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
@@ -171,29 +188,36 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.17.0.tgz",
-      "integrity": "sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==",
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.5.tgz",
-      "integrity": "sha512-o0bhxnL89h5Bae5T318nFoFzGy+YE5i/gGkoPAgkmTVdRKTiv3p8JHevPiPaMwoloKfEiiaHlawCqaZMqRm+XQ==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.4.tgz",
-      "integrity": "sha512-zSkKow6H5Kdm0ZUQUB2kV5JIXqoG0+uH5YADhaEHswm664N9Db8dXSi0nMJpacpMf+MyyglF1vnZohpEg5yUtg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -249,10 +273,11 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
-      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
       },
@@ -586,10 +611,11 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -852,10 +878,11 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -869,6 +896,7 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -975,7 +1003,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -984,10 +1013,11 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1049,6 +1079,7 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -1151,7 +1182,8 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1203,10 +1235,11 @@
       "dev": true
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -1270,32 +1303,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.17.0.tgz",
-      "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
+      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.9.0",
-        "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.17.0",
-        "@eslint/plugin-kit": "^0.2.3",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.39.2",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.1",
+        "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.2.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -1330,10 +1364,11 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
-      "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -1346,10 +1381,11 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1358,14 +1394,15 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1595,6 +1632,7 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1645,10 +1683,11 @@
       }
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -1799,10 +1838,11 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -1955,6 +1995,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2068,6 +2109,7 @@
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -2295,6 +2337,7 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -2457,6 +2500,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "obsidian": "^1.7.2"
   },
   "devDependencies": {
+    "@codemirror/state": "^6.5.4",
+    "@codemirror/view": "^6.39.11",
     "@eslint/js": "^9.17.0",
     "@types/node": "^22.10.2",
     "@types/webpack": "^5.28.5",

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -36,87 +36,57 @@ function getCalloutDivObserver(
   app: App,
 ): MutationObserver {
   return new MutationObserver((mutations) => {
-    mutations.forEach((mutation) => {
-      mutation.addedNodes.forEach((node) => {
-        if (!(node instanceof HTMLElement)) {
-          return;
-        }
-        // Check if node itself is a .cm-callout, or find descendants
-        const newCMCalloutNodes: HTMLElement[] = [];
-        if (node.matches(".cm-callout")) {
-          newCMCalloutNodes.push(node);
-        }
-        newCMCalloutNodes.push(...node.querySelectorAll<HTMLDivElement>(".cm-callout"));
+    // Optimization: Use classic loop for performance
+    for (let i = 0; i < mutations.length; i++) {
+      const mutation = mutations[i];
+      if (!mutation) continue;
+      // Only care about node additions
+      if (mutation.type !== "childList") continue;
 
-        for (const calloutNode of newCMCalloutNodes) {
-          addCopyButtonsAndMoveEditBlockButton({
-            calloutNode,
-            isCMCalloutNode: true,
-            pluginSettingsManager,
-            app,
-          });
-        }
+      const addedNodes = mutation.addedNodes;
+      for (let j = 0; j < addedNodes.length; j++) {
+        const node = addedNodes[j];
+        if (!(node instanceof HTMLElement)) continue;
 
-        // Check if node itself is a .callout, or find descendants
-        // Skip .callout nodes that are inside .cm-callout (already handled above)
-        const newCalloutNodes: HTMLElement[] = [];
-        if (node.matches(".callout") && !node.closest(".cm-callout")) {
-          newCalloutNodes.push(node);
-        }
-        for (const calloutEl of node.querySelectorAll<HTMLDivElement>(".callout")) {
-          if (!calloutEl.closest(".cm-callout")) {
-            newCalloutNodes.push(calloutEl);
+        // OPTIMIZATION: Avoid querySelectorAll and Array spreading.
+        // Check Live Preview Callouts (.cm-callout)
+        if (node.classList.contains("cm-callout")) {
+          processNode(node, true, pluginSettingsManager, app);
+        } else {
+          // Use getElementsByClassName (live collection, faster than querySelectorAll)
+          const cmCallouts = node.getElementsByClassName("cm-callout");
+          for (let k = 0; k < cmCallouts.length; k++) {
+            processNode(cmCallouts[k] as HTMLElement, true, pluginSettingsManager, app);
           }
         }
 
-        for (const calloutNode of newCalloutNodes) {
-          addCopyButtonsAndMoveEditBlockButton({
-            calloutNode,
-            isCMCalloutNode: false,
-            pluginSettingsManager,
-            app,
-          });
+        // Check Standard Callouts (.callout)
+        // Must exclude those inside .cm-callout to prevent duplicates in Live Preview
+        if (node.classList.contains("callout") && !node.closest(".cm-callout")) {
+          processNode(node, false, pluginSettingsManager, app);
+        } else {
+          const callouts = node.getElementsByClassName("callout");
+          for (let k = 0; k < callouts.length; k++) {
+            const calloutEl = callouts[k] as HTMLElement;
+            // closest() check is necessary but can be expensive; do it only on candidates
+            if (!calloutEl.closest(".cm-callout")) {
+              processNode(calloutEl, false, pluginSettingsManager, app);
+            }
+          }
         }
-      });
-    });
+      }
+    }
   });
 }
 
-function addAllCopyButtons(pluginSettingsManager: PluginSettingsManager, app: App): void {
-  const cmCalloutNodes = document.querySelectorAll<HTMLElement>(".cm-callout");
-  cmCalloutNodes.forEach((calloutNode) =>
-    addCopyButtonsAndMoveEditBlockButton({
-      calloutNode,
-      isCMCalloutNode: true,
-      pluginSettingsManager,
-      app,
-    }),
-  );
-  const calloutNodes = document.querySelectorAll<HTMLElement>(".callout");
-  calloutNodes.forEach((calloutNode) =>
-    addCopyButtonsAndMoveEditBlockButton({
-      calloutNode,
-      isCMCalloutNode: false,
-      pluginSettingsManager,
-      app,
-    }),
-  );
-}
-
-function addCopyButtonsAndMoveEditBlockButton({
-  calloutNode,
-  isCMCalloutNode,
-  pluginSettingsManager,
-  app,
-}: {
-  calloutNode: HTMLElement;
-  isCMCalloutNode: boolean;
-  pluginSettingsManager: PluginSettingsManager;
-  app: App;
-}): void {
+function processNode(
+  calloutNode: HTMLElement,
+  isCMCalloutNode: boolean,
+  pluginSettingsManager: PluginSettingsManager,
+  app: App,
+): void {
   addCopyPlainTextButtonToCalloutDiv({ calloutNode, isCMCalloutNode, pluginSettingsManager });
 
-  // Add markdown copy button for Live Preview callouts
   if (isCMCalloutNode) {
     addCopyMarkdownButtonToLivePreviewCallout({ calloutNode, pluginSettingsManager, app });
   }
@@ -124,10 +94,22 @@ function addCopyButtonsAndMoveEditBlockButton({
   moveEditBlockButtonToCalloutActionButtonsWrapper(calloutNode);
 }
 
-/**
- * Adds a "Copy (Markdown)" button to Live Preview callouts.
- * At click time, uses DOM position to find the callout in the editor state.
- */
+function addAllCopyButtons(pluginSettingsManager: PluginSettingsManager, app: App): void {
+  // Use getElementsByClassName for initial load as well
+  const cmCalloutNodes = document.getElementsByClassName("cm-callout");
+  for (let i = 0; i < cmCalloutNodes.length; i++) {
+    processNode(cmCalloutNodes[i] as HTMLElement, true, pluginSettingsManager, app);
+  }
+
+  const calloutNodes = document.getElementsByClassName("callout");
+  for (let i = 0; i < calloutNodes.length; i++) {
+    const node = calloutNodes[i] as HTMLElement;
+    if (!node.closest(".cm-callout")) {
+      processNode(node, false, pluginSettingsManager, app);
+    }
+  }
+}
+
 function addCopyMarkdownButtonToLivePreviewCallout({
   calloutNode,
   pluginSettingsManager,
@@ -137,16 +119,14 @@ function addCopyMarkdownButtonToLivePreviewCallout({
   pluginSettingsManager: PluginSettingsManager;
   app: App;
 }): void {
-  if (calloutNode.querySelector(".callout-copy-button-markdown") !== null) {
-    // Markdown copy button already exists
+  // Simple class check is faster than querySelector
+  if (calloutNode.getElementsByClassName("callout-copy-button-markdown").length > 0) {
     return;
   }
 
   addCopyButtonToCallout({
     calloutNode,
-    getCalloutBodyText: () => {
-      return getMarkdownForCalloutNode(calloutNode, app);
-    },
+    getCalloutBodyText: () => getMarkdownForCalloutNode(calloutNode, app),
     tooltipText: "Copy (Markdown)",
     buttonClassName: "callout-copy-button-markdown",
     isCMCalloutNode: true,
@@ -154,16 +134,10 @@ function addCopyMarkdownButtonToLivePreviewCallout({
   });
 }
 
-/**
- * Gets the markdown content for a callout node by finding its position in the editor.
- */
 function getMarkdownForCalloutNode(calloutNode: HTMLElement, app: App): string | null {
   const editorView = getActiveEditorView(app);
-  if (editorView === null) {
-    return null;
-  }
+  if (!editorView) return null;
 
-  // Try to find the position of this callout in the editor
   let pos: number;
   try {
     pos = editorView.posAtDOM(calloutNode, 0);
@@ -174,54 +148,46 @@ function getMarkdownForCalloutNode(calloutNode: HTMLElement, app: App): string |
   const doc = editorView.state.doc;
   const lineNumber = doc.lineAt(pos).number;
 
-  // Find the callout that contains this line by scanning the document
   const calloutRange = findCalloutRangeContainingLine(doc, lineNumber);
-  if (calloutRange === null) {
-    return null;
-  }
+  if (!calloutRange) return null;
 
   return getCalloutMarkdownFromLines(doc, calloutRange.lineStart, calloutRange.lineEnd);
 }
 
-/**
- * Finds the callout range that contains the given line number.
- * Scans outwards from the target line for O(callout size) complexity
- * instead of O(document size).
- */
 function findCalloutRangeContainingLine(
   doc: { lines: number; line: (n: number) => { text: string } },
   targetLine: number,
 ): { lineStart: number; lineEnd: number } | null {
   const docLineCount = doc.lines;
-
-  // 1. Scan UPWARDS to find the header
   let lineStart = -1;
   let indent = "";
 
+  // 1. Scan UPWARDS
   for (let i = targetLine; i >= 1; i--) {
     const text = doc.line(i).text;
-    const match = CALLOUT_HEADER_REGEX.exec(text);
 
-    // Found the header
-    if (match && match[1]) {
-      lineStart = i;
-      indent = match[1]; // Capture the "> " indentation level
-      break;
+    // Fast path: if line doesn't start with >, it's definitely not part of the callout
+    if (text.charCodeAt(0) !== 62) {
+      // 62 is '>'
+      // Wait, we might be inside a callout that is inside another blockquote?
+      // Just check trim start.
+      if (!text.trimStart().startsWith(">")) return null;
     }
 
-    // If we hit a line that doesn't look like a blockquote before finding a header, abort
-    if (!text.trim().startsWith(">")) {
-      return null;
+    const match = CALLOUT_HEADER_REGEX.exec(text);
+    if (match && match[1]) {
+      lineStart = i;
+      indent = match[1];
+      break;
     }
   }
 
   if (lineStart === -1) return null;
 
-  // 2. Scan DOWNWARDS to find the end
+  // 2. Scan DOWNWARDS
   let lineEnd = targetLine;
   for (let i = targetLine + 1; i <= docLineCount; i++) {
     const text = doc.line(i).text;
-    // If the line doesn't start with the same indent level, the callout has ended
     if (!text.startsWith(indent)) {
       break;
     }

--- a/src/DOMObserver.ts
+++ b/src/DOMObserver.ts
@@ -1,46 +1,80 @@
+import { type App } from "obsidian";
 import { type PluginSettingsManager } from "./settings";
 import {
+  addCopyButtonToCallout,
   addCopyPlainTextButtonToCalloutDiv,
   moveEditBlockButtonToCalloutActionButtonsWrapper,
 } from "./utils/addCopyButtonToCallout";
+import { getActiveEditorView } from "./utils/getEditorView";
+import { getCalloutMarkdownFromLines } from "./utils/getMarkdownFromLines";
+
+const CALLOUT_HEADER_REGEX = /^((?:> )+)\[!.+\]/;
 
 export function watchAndAddCopyButtonsToDOM({
   pluginSettingsManager,
+  app,
 }: {
   pluginSettingsManager: PluginSettingsManager;
+  app: App;
 }): MutationObserver {
-  const observer = watchDOMForNewCallouts(pluginSettingsManager);
-  addAllCopyButtons(pluginSettingsManager);
+  const observer = watchDOMForNewCallouts(pluginSettingsManager, app);
+  addAllCopyButtons(pluginSettingsManager, app);
   return observer;
 }
 
-function watchDOMForNewCallouts(pluginSettingsManager: PluginSettingsManager): MutationObserver {
-  const observer = getCalloutDivObserver(pluginSettingsManager);
+function watchDOMForNewCallouts(
+  pluginSettingsManager: PluginSettingsManager,
+  app: App,
+): MutationObserver {
+  const observer = getCalloutDivObserver(pluginSettingsManager, app);
   observer.observe(document.body, { childList: true, subtree: true });
   return observer;
 }
 
-function getCalloutDivObserver(pluginSettingsManager: PluginSettingsManager): MutationObserver {
+function getCalloutDivObserver(
+  pluginSettingsManager: PluginSettingsManager,
+  app: App,
+): MutationObserver {
   return new MutationObserver((mutations) => {
     mutations.forEach((mutation) => {
       mutation.addedNodes.forEach((node) => {
         if (!(node instanceof HTMLElement)) {
           return;
         }
-        const newCMCalloutNodes = node.querySelectorAll<HTMLDivElement>(".cm-callout");
+        // Check if node itself is a .cm-callout, or find descendants
+        const newCMCalloutNodes: HTMLElement[] = [];
+        if (node.matches(".cm-callout")) {
+          newCMCalloutNodes.push(node);
+        }
+        newCMCalloutNodes.push(...node.querySelectorAll<HTMLDivElement>(".cm-callout"));
+
         for (const calloutNode of newCMCalloutNodes) {
-          addCopyPlainTextButtonAndMoveEditBlockButton({
+          addCopyButtonsAndMoveEditBlockButton({
             calloutNode,
             isCMCalloutNode: true,
             pluginSettingsManager,
+            app,
           });
         }
-        const newCalloutNodes = node.querySelectorAll<HTMLDivElement>(".callout");
+
+        // Check if node itself is a .callout, or find descendants
+        // Skip .callout nodes that are inside .cm-callout (already handled above)
+        const newCalloutNodes: HTMLElement[] = [];
+        if (node.matches(".callout") && !node.closest(".cm-callout")) {
+          newCalloutNodes.push(node);
+        }
+        for (const calloutEl of node.querySelectorAll<HTMLDivElement>(".callout")) {
+          if (!calloutEl.closest(".cm-callout")) {
+            newCalloutNodes.push(calloutEl);
+          }
+        }
+
         for (const calloutNode of newCalloutNodes) {
-          addCopyPlainTextButtonAndMoveEditBlockButton({
+          addCopyButtonsAndMoveEditBlockButton({
             calloutNode,
             isCMCalloutNode: false,
             pluginSettingsManager,
+            app,
           });
         }
       });
@@ -48,34 +82,140 @@ function getCalloutDivObserver(pluginSettingsManager: PluginSettingsManager): Mu
   });
 }
 
-function addAllCopyButtons(pluginSettingsManager: PluginSettingsManager): void {
+function addAllCopyButtons(pluginSettingsManager: PluginSettingsManager, app: App): void {
   const cmCalloutNodes = document.querySelectorAll<HTMLElement>(".cm-callout");
   cmCalloutNodes.forEach((calloutNode) =>
-    addCopyPlainTextButtonAndMoveEditBlockButton({
+    addCopyButtonsAndMoveEditBlockButton({
       calloutNode,
       isCMCalloutNode: true,
       pluginSettingsManager,
-    })
+      app,
+    }),
   );
   const calloutNodes = document.querySelectorAll<HTMLElement>(".callout");
   calloutNodes.forEach((calloutNode) =>
-    addCopyPlainTextButtonAndMoveEditBlockButton({
+    addCopyButtonsAndMoveEditBlockButton({
       calloutNode,
       isCMCalloutNode: false,
       pluginSettingsManager,
-    })
+      app,
+    }),
   );
 }
 
-function addCopyPlainTextButtonAndMoveEditBlockButton({
+function addCopyButtonsAndMoveEditBlockButton({
   calloutNode,
   isCMCalloutNode,
   pluginSettingsManager,
+  app,
 }: {
   calloutNode: HTMLElement;
   isCMCalloutNode: boolean;
   pluginSettingsManager: PluginSettingsManager;
+  app: App;
 }): void {
   addCopyPlainTextButtonToCalloutDiv({ calloutNode, isCMCalloutNode, pluginSettingsManager });
+
+  // Add markdown copy button for Live Preview callouts
+  if (isCMCalloutNode) {
+    addCopyMarkdownButtonToLivePreviewCallout({ calloutNode, pluginSettingsManager, app });
+  }
+
   moveEditBlockButtonToCalloutActionButtonsWrapper(calloutNode);
+}
+
+/**
+ * Adds a "Copy (Markdown)" button to Live Preview callouts.
+ * At click time, uses DOM position to find the callout in the editor state.
+ */
+function addCopyMarkdownButtonToLivePreviewCallout({
+  calloutNode,
+  pluginSettingsManager,
+  app,
+}: {
+  calloutNode: HTMLElement;
+  pluginSettingsManager: PluginSettingsManager;
+  app: App;
+}): void {
+  if (calloutNode.querySelector(".callout-copy-button-markdown") !== null) {
+    // Markdown copy button already exists
+    return;
+  }
+
+  addCopyButtonToCallout({
+    calloutNode,
+    getCalloutBodyText: () => {
+      return getMarkdownForCalloutNode(calloutNode, app);
+    },
+    tooltipText: "Copy (Markdown)",
+    buttonClassName: "callout-copy-button-markdown",
+    isCMCalloutNode: true,
+    pluginSettingsManager,
+  });
+}
+
+/**
+ * Gets the markdown content for a callout node by finding its position in the editor.
+ */
+function getMarkdownForCalloutNode(calloutNode: HTMLElement, app: App): string | null {
+  const editorView = getActiveEditorView(app);
+  if (editorView === null) {
+    return null;
+  }
+
+  // Try to find the position of this callout in the editor
+  let pos: number;
+  try {
+    pos = editorView.posAtDOM(calloutNode, 0);
+  } catch {
+    return null;
+  }
+
+  const doc = editorView.state.doc;
+  const lineNumber = doc.lineAt(pos).number;
+
+  // Find the callout that contains this line by scanning the document
+  const calloutRange = findCalloutRangeContainingLine(doc, lineNumber);
+  if (calloutRange === null) {
+    return null;
+  }
+
+  return getCalloutMarkdownFromLines(doc, calloutRange.lineStart, calloutRange.lineEnd);
+}
+
+/**
+ * Finds the callout range that contains the given line number.
+ */
+function findCalloutRangeContainingLine(
+  doc: { lines: number; line: (n: number) => { text: string } },
+  targetLine: number,
+): { lineStart: number; lineEnd: number } | null {
+  // Scan for callout headers and find one that contains the target line
+  for (let line = 1; line <= doc.lines; line++) {
+    const lineText = doc.line(line).text;
+    const indent = CALLOUT_HEADER_REGEX.exec(lineText)?.[1];
+    if (indent === undefined) {
+      continue;
+    }
+
+    // Found a callout header at this line
+    const lineStart = line;
+    let lineEnd = line;
+
+    // Find the end of this callout
+    for (let i = line + 1; i <= doc.lines; i++) {
+      const bodyLineText = doc.line(i).text;
+      if (!bodyLineText.startsWith(indent)) {
+        break;
+      }
+      lineEnd = i;
+    }
+
+    // Check if target line is within this callout
+    if (targetLine >= lineStart && targetLine <= lineEnd) {
+      return { lineStart, lineEnd };
+    }
+  }
+
+  return null;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,10 @@ export default class CalloutCopyButtonPlugin extends Plugin {
       const calloutCopyButtonViewPlugin = createCalloutCopyButtonViewPlugin(pluginSettingsManager);
       this.registerEditorExtension([calloutCopyButtonViewPlugin]);
       this.registerMarkdownPostProcessor(getMarkdownPostProcessor({ pluginSettingsManager }));
-      this.calloutDivObserver = watchAndAddCopyButtonsToDOM({ pluginSettingsManager });
+      this.calloutDivObserver = watchAndAddCopyButtonsToDOM({
+        pluginSettingsManager,
+        app: this.app,
+      });
     });
   }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,8 @@ import { type Plugin, PluginSettingTab, Setting } from "obsidian";
 
 type SourceModeSettings = {
   showCopyButtonOnlyOnLineHover: boolean;
+  showCopyMarkdownButton: boolean;
+  showCopyPlainTextButton: boolean;
 };
 
 type ReadingModeSettings = {
@@ -34,6 +36,8 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   showCopyFormatIndicators: false,
   sourceModeSettings: {
     showCopyButtonOnlyOnLineHover: false,
+    showCopyMarkdownButton: true,
+    showCopyPlainTextButton: true,
   },
   readingModeSettings: {
     showCopyMarkdownButton: true,
@@ -84,7 +88,7 @@ export class PluginSettingsManager extends PluginSettingTab {
 
   private async setSetting<K extends SettingKey>(
     settingKey: K,
-    value: PluginSettings[K]
+    value: PluginSettings[K],
   ): Promise<void> {
     this.settings[settingKey] = value;
     await this.saveSettings();
@@ -107,22 +111,22 @@ export class PluginSettingsManager extends PluginSettingTab {
 
   private getCopyButtonSettingsClassNames(): Record<string, boolean> {
     const showCopyFormatIndicators = this.getSetting("showCopyFormatIndicators");
-    const { showCopyButtonOnlyOnLineHover } = this.getSetting("sourceModeSettings");
-    const {
-      showCopyMarkdownButton: showCopyMarkdownButton,
-      showCopyPlainTextButton: showCopyPlainTextButton,
-    } = this.getSetting("readingModeSettings");
+    const sourceModeSettings = this.getSetting("sourceModeSettings");
+    const readingModeSettings = this.getSetting("readingModeSettings");
     return {
       "show-copy-format-indicators": showCopyFormatIndicators,
-      "show-source-mode-copy-button-only-on-line-hover": showCopyButtonOnlyOnLineHover,
-      "show-reading-mode-copy-markdown-buttons": showCopyMarkdownButton,
-      "show-reading-mode-copy-plain-text-buttons": showCopyPlainTextButton,
+      "show-source-mode-copy-button-only-on-line-hover":
+        sourceModeSettings.showCopyButtonOnlyOnLineHover,
+      "show-source-mode-copy-markdown-buttons": sourceModeSettings.showCopyMarkdownButton,
+      "show-source-mode-copy-plain-text-buttons": sourceModeSettings.showCopyPlainTextButton,
+      "show-reading-mode-copy-markdown-buttons": readingModeSettings.showCopyMarkdownButton,
+      "show-reading-mode-copy-plain-text-buttons": readingModeSettings.showCopyPlainTextButton,
     };
   }
 
   private async setSourceModeSetting<K extends keyof SourceModeSettings>(
     modeKey: K,
-    value: SourceModeSettings[K]
+    value: SourceModeSettings[K],
   ): Promise<void> {
     const newSourceModeSettings = { ...this.settings.sourceModeSettings, [modeKey]: value };
     await this.setSetting("sourceModeSettings", newSourceModeSettings);
@@ -130,7 +134,7 @@ export class PluginSettingsManager extends PluginSettingTab {
 
   private async setReadingModeSetting<K extends keyof ReadingModeSettings>(
     modeKey: K,
-    value: ReadingModeSettings[K]
+    value: ReadingModeSettings[K],
   ): Promise<void> {
     const newReadingModeSettings = { ...this.settings.readingModeSettings, [modeKey]: value };
     await this.setSetting("readingModeSettings", newReadingModeSettings);
@@ -155,18 +159,20 @@ export class PluginSettingsManager extends PluginSettingTab {
     new Setting(this.containerEl)
       .setName("Show copy format indicators on copy buttons")
       .setDesc(
-        "Whether to add little 'P' (plain text) and 'M' (Markdown) indicators to the copy buttons that indicate what format the copied content will be in."
+        "Whether to add little 'P' (plain text) and 'M' (Markdown) indicators to the copy buttons that indicate what format the copied content will be in.",
       )
       .addToggle((toggle) =>
         toggle
           .setValue(this.settings.showCopyFormatIndicators)
-          .onChange((value) => this.setSetting("showCopyFormatIndicators", value))
+          .onChange((value) => this.setSetting("showCopyFormatIndicators", value)),
       );
   }
 
   private displaySourceModeSettings(): void {
     new Setting(this.containerEl).setName("Source mode").setHeading();
     this.displayShowCopyButtonOnlyOnLineHoverSetting();
+    this.displaySourceModeShowCopyMarkdownButtonSetting();
+    this.displaySourceModeShowCopyPlainTextButtonSetting();
   }
 
   private displayShowCopyButtonOnlyOnLineHoverSetting(): void {
@@ -176,7 +182,29 @@ export class PluginSettingsManager extends PluginSettingTab {
       .addToggle((toggle) =>
         toggle
           .setValue(this.settings.sourceModeSettings.showCopyButtonOnlyOnLineHover)
-          .onChange((value) => this.setSourceModeSetting("showCopyButtonOnlyOnLineHover", value))
+          .onChange((value) => this.setSourceModeSetting("showCopyButtonOnlyOnLineHover", value)),
+      );
+  }
+
+  private displaySourceModeShowCopyMarkdownButtonSetting(): void {
+    new Setting(this.containerEl)
+      .setName("Show 'Copy (Markdown)' button")
+      .setDesc("Whether to add 'Copy (Markdown)' buttons to callout blocks in Source Mode.")
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.settings.sourceModeSettings.showCopyMarkdownButton)
+          .onChange((value) => this.setSourceModeSetting("showCopyMarkdownButton", value)),
+      );
+  }
+
+  private displaySourceModeShowCopyPlainTextButtonSetting(): void {
+    new Setting(this.containerEl)
+      .setName("Show 'Copy (plain text)' button")
+      .setDesc("Whether to add 'Copy (plain text)' buttons to callout blocks in Source Mode.")
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.settings.sourceModeSettings.showCopyPlainTextButton)
+          .onChange((value) => this.setSourceModeSetting("showCopyPlainTextButton", value)),
       );
   }
 
@@ -193,7 +221,7 @@ export class PluginSettingsManager extends PluginSettingTab {
       .addToggle((toggle) =>
         toggle
           .setValue(this.settings.readingModeSettings.showCopyMarkdownButton)
-          .onChange((value) => this.setReadingModeSetting("showCopyMarkdownButton", value))
+          .onChange((value) => this.setReadingModeSetting("showCopyMarkdownButton", value)),
       );
   }
 
@@ -204,7 +232,7 @@ export class PluginSettingsManager extends PluginSettingTab {
       .addToggle((toggle) =>
         toggle
           .setValue(this.settings.readingModeSettings.showCopyPlainTextButton)
-          .onChange((value) => this.setReadingModeSetting("showCopyPlainTextButton", value))
+          .onChange((value) => this.setReadingModeSetting("showCopyPlainTextButton", value)),
       );
   }
 

--- a/src/utils/getCalloutBodyText.ts
+++ b/src/utils/getCalloutBodyText.ts
@@ -46,7 +46,7 @@ export function getCalloutBodyLines({
 }
 
 export function getCalloutBodyTextFromSectionInfo(
-  calloutSectionInfo: MarkdownSectionInformation
+  calloutSectionInfo: MarkdownSectionInformation,
 ): string | null {
   const calloutBodyLines = getCalloutBodyLinesFromSectionInfo(calloutSectionInfo);
   if (calloutBodyLines === null) {
@@ -56,7 +56,7 @@ export function getCalloutBodyTextFromSectionInfo(
 }
 
 function getCalloutBodyLinesFromSectionInfo(
-  calloutSectionInfo: MarkdownSectionInformation
+  calloutSectionInfo: MarkdownSectionInformation,
 ): string[] | null {
   const { text, lineStart, lineEnd } = calloutSectionInfo;
   const allLines = text.split("\n");
@@ -79,4 +79,19 @@ function getCalloutBodyLinesFromSectionInfo(
     calloutBodyLines.push(calloutBodyLineText);
   }
   return calloutBodyLines;
+}
+
+/**
+ * Strips the leading "> " quote markers from each line of the callout body text.
+ * This converts raw markdown callout body lines to plain text format.
+ */
+export function stripLeadingQuoteMarkers(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => {
+      // Strip leading "> " patterns (one or more levels)
+      return line.replace(/^(?:> )+/, "");
+    })
+    .join("\n")
+    .trim();
 }

--- a/src/utils/getCalloutBodyText.ts
+++ b/src/utils/getCalloutBodyText.ts
@@ -86,12 +86,8 @@ function getCalloutBodyLinesFromSectionInfo(
  * This converts raw markdown callout body lines to plain text format.
  */
 export function stripLeadingQuoteMarkers(text: string): string {
-  return text
-    .split("\n")
-    .map((line) => {
-      // Strip leading "> " patterns (one or more levels)
-      return line.replace(/^(?:> )+/, "");
-    })
-    .join("\n")
-    .trim();
+  // OPTIMIZATION: Using a global multiline regex replace is often faster
+  // and creates fewer intermediate objects than split/map/join for simple patterns.
+  if (!text) return "";
+  return text.replace(/^(?:> )+/gm, "").trim();
 }

--- a/src/utils/getEditorView.ts
+++ b/src/utils/getEditorView.ts
@@ -1,0 +1,16 @@
+import { type App, MarkdownView } from "obsidian";
+import type { EditorView } from "@codemirror/view";
+
+/**
+ * Gets the CodeMirror EditorView from the currently active markdown view.
+ * Returns null if no active markdown view or editor is available.
+ */
+export function getActiveEditorView(app: App): EditorView | null {
+  const view = app.workspace.getActiveViewOfType(MarkdownView);
+  if (view === null) {
+    return null;
+  }
+  // @ts-expect-error - accessing internal CM6 editor property
+  const editorView: EditorView | undefined = view.editor?.cm;
+  return editorView ?? null;
+}

--- a/src/utils/getMarkdownFromLines.ts
+++ b/src/utils/getMarkdownFromLines.ts
@@ -1,0 +1,38 @@
+import { type Text } from "@codemirror/state";
+
+const CALLOUT_HEADER_WITH_INDENT_CAPTURE_REGEX = /^((?:> )+)\[!.+\]/;
+
+/**
+ * Extracts the callout body markdown from a document given the line range.
+ * Strips the callout indent prefix (e.g., "> ") from each body line.
+ *
+ * @param doc - CodeMirror document
+ * @param lineStart - 1-indexed line number of the callout header
+ * @param lineEnd - 1-indexed line number of the last line of the callout
+ * @returns The callout body with indent stripped, or null if not a valid callout
+ */
+export function getCalloutMarkdownFromLines(
+  doc: Text,
+  lineStart: number,
+  lineEnd: number,
+): string | null {
+  if (lineStart < 1 || lineEnd > doc.lines || lineStart > lineEnd) {
+    return null;
+  }
+
+  const headerLine = doc.line(lineStart).text;
+  const indent = CALLOUT_HEADER_WITH_INDENT_CAPTURE_REGEX.exec(headerLine)?.[1];
+  if (indent === undefined) {
+    return null;
+  }
+
+  const bodyLines: string[] = [];
+  for (let i = lineStart + 1; i <= lineEnd; i++) {
+    const line = doc.line(i).text;
+    if (!line.startsWith(indent)) {
+      break;
+    }
+    bodyLines.push(line.slice(indent.length));
+  }
+  return bodyLines.join("\n");
+}

--- a/src/viewPlugin/copyButtonWidget.ts
+++ b/src/viewPlugin/copyButtonWidget.ts
@@ -3,32 +3,43 @@ import classNames from "classnames";
 import { setIcon } from "obsidian";
 import { type PluginSettingsManager } from "../settings";
 import { addClassNames } from "../utils/addClassNames";
+import { stripLeadingQuoteMarkers } from "../utils/getCalloutBodyText";
 
-export class CopyButtonWidget extends WidgetType {
-  constructor(private text: string, private pluginSettingsManager: PluginSettingsManager) {
+type CopyButtonType = "markdown" | "plain-text";
+
+abstract class BaseCopyButtonWidget extends WidgetType {
+  constructor(
+    protected text: string,
+    protected pluginSettingsManager: PluginSettingsManager,
+    protected buttonType: CopyButtonType,
+  ) {
     super();
   }
 
+  protected abstract getTextToCopy(): string;
+  protected abstract getTooltip(): string;
+
   toDOM(): HTMLElement {
     const copyButton = document.createElement("div");
+    const buttonTypeClass = `callout-copy-button-${this.buttonType}`;
     const className = classNames(
       "callout-copy-button",
       "callout-copy-button-widget",
-      "callout-copy-button-markdown",
-      this.pluginSettingsManager.getCopyButtonSettingsClassName()
+      buttonTypeClass,
+      this.pluginSettingsManager.getCopyButtonSettingsClassName(),
     );
     addClassNames({ el: copyButton, classNames: className });
-    copyButton.setAttribute("aria-label", "Copy (Markdown)");
+    copyButton.setAttribute("aria-label", this.getTooltip());
 
     setIcon(copyButton, "copy");
 
     copyButton.addEventListener("click", (e) => {
       e.stopPropagation();
       if (copyButton.hasAttribute("disabled")) return;
+      const textToCopy = this.getTextToCopy();
       navigator.clipboard
-        .writeText(this.text)
+        .writeText(textToCopy)
         .then(() => {
-          // console.log(`Copied: ${JSON.stringify(this.text)}`);
           setIcon(copyButton, "check");
           copyButton.addClass("just-copied");
           copyButton.setAttribute("disabled", "true");
@@ -51,3 +62,34 @@ export class CopyButtonWidget extends WidgetType {
     return true;
   }
 }
+
+export class CopyMarkdownButtonWidget extends BaseCopyButtonWidget {
+  constructor(text: string, pluginSettingsManager: PluginSettingsManager) {
+    super(text, pluginSettingsManager, "markdown");
+  }
+
+  protected getTextToCopy(): string {
+    return this.text;
+  }
+
+  protected getTooltip(): string {
+    return "Copy (Markdown)";
+  }
+}
+
+export class CopyPlainTextButtonWidget extends BaseCopyButtonWidget {
+  constructor(text: string, pluginSettingsManager: PluginSettingsManager) {
+    super(text, pluginSettingsManager, "plain-text");
+  }
+
+  protected getTextToCopy(): string {
+    return stripLeadingQuoteMarkers(this.text);
+  }
+
+  protected getTooltip(): string {
+    return "Copy (plain text)";
+  }
+}
+
+// Keep the old name for backward compatibility
+export { CopyMarkdownButtonWidget as CopyButtonWidget };

--- a/src/viewPlugin/copyButtonWidget.ts
+++ b/src/viewPlugin/copyButtonWidget.ts
@@ -19,6 +19,15 @@ abstract class BaseCopyButtonWidget extends WidgetType {
   protected abstract getTextToCopy(): string;
   protected abstract getTooltip(): string;
 
+  // OPTIMIZATION: Critical for CodeMirror performance.
+  // Prevents destroying/recreating the DOM node if parameters haven't changed.
+  eq(other: BaseCopyButtonWidget): boolean {
+    return (
+      other.text === this.text && other.buttonType === this.buttonType
+      // PluginSettingsManager is a singleton reference, so strict equality is fine.
+    );
+  }
+
   toDOM(): HTMLElement {
     const copyButton = document.createElement("div");
     const buttonTypeClass = `callout-copy-button-${this.buttonType}`;

--- a/src/viewPlugin/viewPlugin.ts
+++ b/src/viewPlugin/viewPlugin.ts
@@ -1,21 +1,75 @@
-import { RangeSetBuilder } from "@codemirror/state";
+import { RangeSetBuilder, StateField, type EditorState, type Extension } from "@codemirror/state";
 import {
   Decoration,
+  ViewPlugin,
   type DecorationSet,
   type EditorView,
   type PluginSpec,
   type PluginValue,
-  ViewPlugin,
   type ViewUpdate,
 } from "@codemirror/view";
 import { type PluginSettingsManager } from "../settings";
 import { getCalloutBodyLines } from "../utils/getCalloutBodyText";
-import { CopyButtonWidget } from "./copyButtonWidget";
+import { CopyMarkdownButtonWidget, CopyPlainTextButtonWidget } from "./copyButtonWidget";
 
 const CALLOUT_HEADER_WITH_INDENT_CAPTURE_REGEX = /^((?:> )+)\[!.+\]/;
 
+/**
+ * Information about a callout's position in the document.
+ */
+export interface CalloutLineRange {
+  lineStart: number;
+  lineEnd: number;
+}
+
+/**
+ * StateField that tracks all callout line ranges in the document.
+ * This enables other parts of the code to look up callout positions.
+ */
+export const calloutRangesField = StateField.define<CalloutLineRange[]>({
+  create(state: EditorState): CalloutLineRange[] {
+    return computeCalloutRanges(state);
+  },
+  update(
+    value: CalloutLineRange[],
+    tr: { docChanged: boolean; state: EditorState },
+  ): CalloutLineRange[] {
+    if (tr.docChanged) {
+      return computeCalloutRanges(tr.state);
+    }
+    return value;
+  },
+});
+
+function computeCalloutRanges(state: EditorState): CalloutLineRange[] {
+  const ranges: CalloutLineRange[] = [];
+  const doc = state.doc;
+
+  for (let line = 1; line <= doc.lines; line++) {
+    const lineText = doc.line(line).text;
+    const calloutIndent = CALLOUT_HEADER_WITH_INDENT_CAPTURE_REGEX.exec(lineText)?.[1];
+    if (calloutIndent === undefined) {
+      continue;
+    }
+
+    // Find the end of this callout
+    let lineEnd = line;
+    for (let i = line + 1; i <= doc.lines; i++) {
+      const bodyLineText = doc.line(i).text;
+      if (!bodyLineText.startsWith(calloutIndent)) {
+        break;
+      }
+      lineEnd = i;
+    }
+
+    ranges.push({ lineStart: line, lineEnd });
+  }
+
+  return ranges;
+}
+
 export function createCalloutCopyButtonViewPlugin(
-  pluginSettingsManager: PluginSettingsManager
+  pluginSettingsManager: PluginSettingsManager,
 ): ViewPlugin<PluginValue> {
   class CalloutCopyButtonViewPlugin implements PluginValue {
     decorations: DecorationSet;
@@ -51,12 +105,33 @@ export function createCalloutCopyButtonViewPlugin(
           bodyStartLine: line + 1,
         });
         const calloutBodyText = calloutBodyLines.join("\n");
-        const deco = Decoration.widget({
-          widget: new CopyButtonWidget(calloutBodyText, pluginSettingsManager),
+
+        // Calculate the end line of this callout
+        const lineEnd = line + calloutBodyLines.length;
+
+        const headerLineInfo = doc.line(line);
+
+        // Add line decoration with data attributes for Live Preview
+        const lineDeco = Decoration.line({
+          attributes: {
+            "data-callout-line-start": String(line),
+            "data-callout-line-end": String(lineEnd),
+          },
+        });
+        builder.add(headerLineInfo.from, headerLineInfo.from, lineDeco);
+
+        // Add widget decorations for Source Mode copy buttons (markdown and plain text)
+        const markdownWidgetDeco = Decoration.widget({
+          widget: new CopyMarkdownButtonWidget(calloutBodyText, pluginSettingsManager),
           side: 1, // Place the widget on the right
         });
-        const from = doc.line(line).from;
-        builder.add(from, from, deco);
+        builder.add(headerLineInfo.from, headerLineInfo.from, markdownWidgetDeco);
+
+        const plainTextWidgetDeco = Decoration.widget({
+          widget: new CopyPlainTextButtonWidget(calloutBodyText, pluginSettingsManager),
+          side: 1, // Place the widget after the markdown button
+        });
+        builder.add(headerLineInfo.from, headerLineInfo.from, plainTextWidgetDeco);
       }
 
       return builder.finish();
@@ -68,4 +143,14 @@ export function createCalloutCopyButtonViewPlugin(
   };
 
   return ViewPlugin.fromClass(CalloutCopyButtonViewPlugin, pluginSpec);
+}
+
+/**
+ * Returns the extensions needed for callout copy functionality.
+ * Includes both the StateField for tracking callout ranges and the ViewPlugin.
+ */
+export function createCalloutCopyButtonExtensions(
+  pluginSettingsManager: PluginSettingsManager,
+): Extension[] {
+  return [calloutRangesField, createCalloutCopyButtonViewPlugin(pluginSettingsManager)];
 }

--- a/styles.css
+++ b/styles.css
@@ -83,11 +83,27 @@ div[data-mode="preview"] {
   }
 }
 
+/* Live Preview mode (.cm-callout) - respect source mode settings */
+.cm-callout {
+  .callout-copy-button-markdown:not(.show-source-mode-copy-markdown-buttons) {
+    display: none;
+  }
+  .callout-copy-button-plain-text:not(.show-source-mode-copy-plain-text-buttons) {
+    display: none;
+  }
+}
+
 .callout-copy-button-widget {
   position: absolute;
   top: 0px;
   inset-inline-end: 0px;
   &:not(.show-source-mode-copy-button-only-on-line-hover) {
     opacity: 1;
+  }
+  &.callout-copy-button-markdown:not(.show-source-mode-copy-markdown-buttons) {
+    display: none;
+  }
+  &.callout-copy-button-plain-text:not(.show-source-mode-copy-plain-text-buttons) {
+    display: none;
   }
 }


### PR DESCRIPTION
- **Feature Added:**
    - Enabled the "Copy Markdown" functionality specifically for Live Preview (CM6) callouts, where it was previously unavailable.
- **Technical Implementation:**
    - Since Live Preview renders the final HTML rather than the raw text, extracting the Markdown requires a lookup.
    - By using `view.posAtDOM()`, the plugin resolves the visual button's location to a specific index in the document.
    - It then scans the document state from that index to capture the relevant lines, ensuring the copied text matches the raw source exactly.

![copy-markdown](https://github.com/user-attachments/assets/7d8db412-ca1c-426d-bd93-6c8199cfe123)
